### PR TITLE
Fix: only last keyword results in correct match

### DIFF
--- a/lib/handlebars-xgettext.js
+++ b/lib/handlebars-xgettext.js
@@ -24,7 +24,7 @@ var keywords = [
 ];
 
 // Basic constants.
-/** @const */ var split_pattern = RegExp('\{\{' + keywords.join('|') + ' "', 'g');
+/** @const */ var split_pattern = RegExp('\{\{(?:' + keywords.join('|') + ') "', 'g');
 /** @const */ var line_start = 'msgid "';
 /** @const */ var line_end = '"\nmsgstr ""\n\n';
 


### PR DESCRIPTION
Fixes split_pattern so any of the keywords can be matched.

Previously, keywords ["gettext","_"] resulted in the regex: `{{gettext|_ "`which is wrong, as it's looking for`{{gettext`OR`_ "`.

The result is that if you use `{{gettext "test"}}` it's actually going to result in an empty string coming back to the .pot file. Likewise, if you have just a literal `_ "test"` (without curly braces) in the file, it will be falsely matched.

This fix changes it so the regex is actually `{{(gettext|_) "` so that the OR logic works correctly.
