### PR TITLE
adding support to angularjs templates. So one can use handlebars or angular in the client-side

### DIFF
--- a/lib/handlebars-xgettext.js
+++ b/lib/handlebars-xgettext.js
@@ -19,12 +19,13 @@ var fs = require('fs');
 var from_code = 'utf-8';
 var join_existing = false;
 var keywords = [
+  'getText',
   'gettext',
   '_'
 ];
 
 // Basic constants.
-/** @const */ var split_pattern = RegExp('\{\{' + keywords.join('|') + '\\s?\\(?"', 'g');
+/** @const */ var split_pattern = RegExp(keywords.join('|') + '\\s?\\(?"', 'g');
 /** @const */ var line_start = 'msgid "';
 /** @const */ var line_end = '"\nmsgstr ""\n\n';
 
@@ -49,11 +50,13 @@ function parse(dir, dstFile) {
     files.sort();
 
     files.forEach(function(file) {
-      var data = fs.readFileSync(file, from_code);
-
-      newKeys = extract_i18n(data);
-      for (i in newKeys) {
-        keys[i] = newKeys[i];
+      if (file.match(/js$/) || file.match(/html?$/)) {// Only JavaScript or HTML Files
+        var data = fs.readFileSync(file, from_code);
+        console.log("Reading file: " + file);
+        newKeys = extract_i18n(data);
+        for (i in newKeys) {
+          keys[i] = newKeys[i];
+        }
       }
     });
 


### PR DESCRIPTION
I've changed a bit the RegEx used in the parsing process so a developer can use handlebars-gettext to generate .po files to handlebar templates or to angularjs markup language.

I think It would be a nice feature to make this adaptable to even other templates languages (ex.: ejs/ajs, jade, etc).
