### PR TITLE
Added support for single quotes

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -14,7 +14,7 @@ function Parser(keywords) {
 
   this.keywords = keywords;
 
-  this.pattern = new RegExp('\\{\\{(?:' + keywords.join('|') + ') "((?:\\\\.|[^"\\\\])*)"(?: "((?:\\\\.|[^"\\\\])*)" \\w+)? ?\\}\\}', 'gm');
+  this.pattern = new RegExp('\\{\\{(?:' + keywords.join('|') + ') [\'"]((?:\\\\.|[^\'"\\\\])*)[\'"](?: [\'"]((?:\\\\.|[^\'"\\\\])*)[\'"] \\w+)? ?\\}\\}', 'gm');
 }
 
 /**

--- a/test/fixtures/plural.hbs
+++ b/test/fixtures/plural.hbs
@@ -1,1 +1,2 @@
 <p>{{_ "book" "books" amount}}</p>
+<p>{{_ 'car' 'cars' amount}}</p>

--- a/test/fixtures/template.hbs
+++ b/test/fixtures/template.hbs
@@ -1,5 +1,6 @@
 <h1>{{_ "This is a title"}}</h1>
 <p>{{_ "This is a fixed sentence"}}</p>
+<p>{{_ 'This is wrapped in single quotes'}}</p>
 <p>{{nl2br description}}</p>
 <img src="someimage.png" alt="{{_ "Image description"}}" />
 <p>{{_ "Multiline

--- a/test/handlebars-xgettext_test.js
+++ b/test/handlebars-xgettext_test.js
@@ -23,8 +23,8 @@ exports.INPUT = {
 
       comment = context['Image description'].comments;
       test.deepEqual(comment.reference.split('\n'), [
-          'test/fixtures/template.hbs:4',
-          'test/fixtures/template.hbs:7'
+          'test/fixtures/template.hbs:5',
+          'test/fixtures/template.hbs:8'
         ], 'Repeated msgid in one file is not tracked');
 
       test.done();

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -12,7 +12,7 @@ exports.parser = {
       result = parser.parse(template);
 
     test.equal(typeof result, 'object', 'No object returned');
-    test.equal(Object.keys(result).length, 5, 'Invalid amount of strings returned');
+    test.equal(Object.keys(result).length, 6, 'Invalid amount of strings returned');
     test.equal(result['Image description'].line.length, 2, 'Invalid amount of lines returned for string');
 
     test.done();
@@ -24,7 +24,7 @@ exports.parser = {
       template = fs.readFileSync(templatePath, 'utf8'),
       result = parser.parse(template);
 
-    test.equal(Object.keys(result).length, 1, 'Invalid amount of strings returned');
+    test.equal(Object.keys(result).length, 2, 'Invalid amount of strings returned');
 
     test.done();
   }


### PR DESCRIPTION
Added support for single quotes, so that both these forms are recognized in the handlebars templates:
{{_ "foo"}}
{{_ 'foo'}}

This should fix issue #25.
