### PR TITLE
Skip non-parseable files with warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,8 @@ function xgettext(input, options, cb) {
                     language = options.language || xgettext.languages[extension];
 
                   if (!language) {
-                    throw 'No language specified for extension \'' + extension + '\'.';
+                    console.log('No language specified for extension \'' + extension + '\'.');
+                    return cb();
                   }
 
                   parseTemplate(getParser(language, spec), res, addPath(file.replace(/\\/, '/')));


### PR DESCRIPTION
There are some files which might be present in templates directory which are not actual templates, for instance OSX Finder clutter like .DS_Store. This PR just skips such files with warning.