### PR TITLE
Support handlebars extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,6 +168,7 @@ function xgettext(input, options, cb) {
 
 xgettext.languages = {
   '.hbs': 'Handlebars',
+  '.handlebars': 'Handlebars',
   '.swig': 'Swig'
 };
 


### PR DESCRIPTION
We have some Handlebars templates with an extension of `.handlebars`, and it'd be nice to be able to extract translations from them.