### PR TITLE
Add support for EJS templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Extracts translatable strings from source. Identical to [xgettext(1)](http://www
 * Handlebars (using [gettext-handlebars](https://github.com/smhg/gettext-handlebars))
 * Swig (using [gettext-swig](https://github.com/smhg/gettext-swig))
 * Volt (using [gettext-volt](https://github.com/perchlayer/gettext-volt))
+* EJS (using [gettext-ejs](https://github.com/pekala/gettext-ejs))
 
 React's **JSX** and **Jade** are todos (PRs are much appreciated).
 

--- a/index.js
+++ b/index.js
@@ -156,7 +156,8 @@ function xgettext(input, options, cb) {
 xgettext.languages = {
   '.hbs': 'Handlebars',
   '.swig': 'Swig',
-  '.volt': 'Volt'
+  '.volt': 'Volt',
+  '.ejs': 'EJS'
 };
 
 module.exports = xgettext;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "async": "1.5.2",
     "colors": "1.1.2",
+    "gettext-ejs": "0.1.0",
     "gettext-handlebars": "0.4.1",
     "gettext-parser": "1.1.2",
     "gettext-swig": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "async": "1.5.2",
     "colors": "1.1.2",
-    "gettext-ejs": "0.1.0",
+    "gettext-ejs": "0.1.1",
     "gettext-handlebars": "0.4.1",
     "gettext-parser": "1.1.2",
     "gettext-swig": "0.2.0",


### PR DESCRIPTION
Adds support for EJS templates with multiple options for open and close tags (`<%`, `{{`, `{*`).