### PR TITLE
Do not error out on no input files

### DIFF
--- a/bin/xgettext-template
+++ b/bin/xgettext-template
@@ -53,10 +53,6 @@ var argv = require('yargs')
       throw new Error('Encoding of input files must be either utf8, ascii or base64.'.red);
     }
 
-    if (argv._.length === 0 && !argv['files-from'] && !argv.directory) {
-      throw new Error('No input file given.'.red);
-    }
-
     return true;
   })
   .argv;

--- a/test/cli.js
+++ b/test/cli.js
@@ -37,11 +37,13 @@ var run = function (args, onErr, onEnd) {
 };
 
 describe('CLI', function () {
-  it('should not run without parameters or input', function (done) {
+  it('should run without parameters or input', function (done) {
     run([], function () {
+      throw new Error('Errored out for no parameters or input');
+    }, function (code, data) {
+      assert.equal(0, code);
+      assert.equal(data, '');
       done();
-    }, function () {
-      throw new Error('Ran without parameters or input');
     });
   });
 


### PR DESCRIPTION
This aligns behaviour with original `xgettext`. Erroring out for no input files makes it diffucult to use this tool as a part of `Makefile`. 