### PR TITLE
Add support for msgctxt

### DIFF
--- a/test/fixtures/contexts-mixed.hbs
+++ b/test/fixtures/contexts-mixed.hbs
@@ -1,0 +1,3 @@
+<h1>Only one string below has context.</h1>
+<p>{{p_ "menu" "Localized string"}}</p>
+<p>{{_ "Localized string"}}</p>

--- a/test/fixtures/contexts-plural.hbs
+++ b/test/fixtures/contexts-plural.hbs
@@ -1,0 +1,2 @@
+<h1>The string below is both plural and has context.</h1>
+<p>{{np_ "menu" "item" "items" count}}</p>

--- a/test/fixtures/contexts.hbs
+++ b/test/fixtures/contexts.hbs
@@ -1,0 +1,3 @@
+<h1>Strings below have contexts.</h1>
+<p>{{p_ "menu" "Localized string"}}</p>
+<p>{{p_ "body" "Localized string"}}</p>

--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,36 @@ describe('API', function () {
       done();
     });
   });
+  it('should handle different translation contexts in single file', function (done) {
+    xgettext(['test/fixtures/contexts.hbs'], {output: '-'}, function (po) {
+      var translations = gt.po.parse(po).translations;
+
+      assert(translations !== undefined);
+      assert('menu' in translations);
+      assert('body' in translations);
+      assert('Localized string' in translations.menu);
+      assert('Localized string' in translations.body);
+      assert.equal(translations.menu['Localized string'].msgctxt, 'menu');
+      assert.equal(translations.body['Localized string'].msgctxt, 'body');
+
+      done();
+    });
+  });
+  it('should handle translation contexts along with simple strings', function (done) {
+    xgettext(['test/fixtures/contexts-mixed.hbs'], {output: '-'}, function (po) {
+      var translations = gt.po.parse(po).translations;
+
+      assert(translations !== undefined);
+      assert('menu' in translations);
+      assert('' in translations);
+      assert('Localized string' in translations.menu);
+      assert('Localized string' in translations['']);
+      assert.equal(translations.menu['Localized string'].msgctxt, 'menu');
+      assert(!translations['']['Localized string'].msgctxt);
+
+      done();
+    });
+  });
   it('should handle non-ascii input', function (done) {
     xgettext(['test/fixtures/non-ascii.hbs'], {output: '-'}, function (po) {
       var context = gt.po.parse(po, 'utf-8').translations[''];

--- a/test/index.js
+++ b/test/index.js
@@ -101,6 +101,21 @@ describe('API', function () {
       done();
     });
   });
+  it('should handle plural strings with translation contexts', function (done) {
+    xgettext(['test/fixtures/contexts-plural.hbs'], {output: '-'}, function (po) {
+      var translations = gt.po.parse(po).translations;
+
+      assert(translations !== undefined);
+      assert('menu' in translations);
+      assert('item' in translations.menu);
+      assert.equal(translations.menu.item.msgid, 'item');
+      assert.equal(translations.menu.item.msgid_plural, 'items');
+      assert.equal(translations.menu.item.msgstr.length, 2);
+      assert.equal(translations.menu.item.msgctxt, 'menu');
+
+      done();
+    });
+  });
   it('should handle non-ascii input', function (done) {
     xgettext(['test/fixtures/non-ascii.hbs'], {output: '-'}, function (po) {
       var context = gt.po.parse(po, 'utf-8').translations[''];


### PR DESCRIPTION
Take into account message context returned by the parser and correctly handle such strings.
Probably, it will be a prerequisite for #56.