### PR TITLE
Ensure path comments are correctly normalized on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ function xgettext(input, options, cb) {
 
     var files = options.directory.reduce(function (result, directory) {
       return result.concat(input.map(function (file) {
-        return path.join(directory, file);
+        return path.join(directory, file.replace(/\\/g, path.sep));
       }));
     }, []);
 

--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ function xgettext(input, options, cb) {
             throw 'No language specified for extension \'' + extension + '\'.';
           }
 
-          parseTemplate(getParser(language, keywordSpec), res, addPath(file.replace(/\\/, '/')));
+          parseTemplate(getParser(language, keywordSpec), res, addPath(file.replace(/\\/g, '/')));
 
           cb();
         });

--- a/test/index.js
+++ b/test/index.js
@@ -218,6 +218,18 @@ describe('API', function () {
       done();
     });
   });
+  it('should handle windows-style paths', function (done) {
+    xgettext(['test\\fixtures\\repeat.hbs'], {
+      output: '-'
+    }, function (po) {
+      var context = gt.po.parse(po).translations[''];
+      var comment = context['This is a fixed sentence'].comments || {};
+
+      assert(comment.reference === 'test/fixtures/repeat.hbs:2');
+
+      done();
+    });
+  });
   it('should handle force-po option', function (done) {
     xgettext(['test/fixtures/fixed.hbs'], {
       'force-po': true,


### PR DESCRIPTION
Currently, when running the extraction on Windows you'd get paths like this: `\app\template.hbs`. This is especially annoying when some developers use Windows and others don't, as this will constantly change in the .pot file (depending on who did the extraction), leading to noisy Git commits.

This PR will ensure that these paths are always consistent with `/` instead of `\`.